### PR TITLE
Allow viewing and running qml apps installed in dev directory

### DIFF
--- a/src/core/package/application_description.cpp
+++ b/src/core/package/application_description.cpp
@@ -118,8 +118,7 @@ bool ApplicationDescription::LoadJson(pbnjson::JValue& jdesc, const AppTypeByDir
   else if ("stub" == app_type) app_type_ = AppType::Stub;
   else if ("native" == app_type) app_type_ = (privileged_jail) ? AppType::Native_Mvpd : AppType::Native;
   else if ("native_builtin" == app_type) app_type_ = AppType::Native_Builtin;
-  else if ("qml" == app_type &&
-           (AppTypeByDir::System_BuiltIn == type_by_dir || AppTypeByDir::System_Updatable == type_by_dir)) {
+  else if ("qml" == app_type) {
     if (SettingsImpl::instance().use_qml_booster_) app_type_ = AppType::Qml;
     else app_type_ = AppType::Native_Qml;
   }


### PR DESCRIPTION
:Release Notes:
Allow viewing and running qml apps installed in dev directory

:Detailed Notes:
Because sam ignored appinfo metadata of qml app installed in the
dev directory, therefore the qml apps were not exposed by 'listApps'
ls api and no way to launch it.
This code-patch gets rid of this problem.

:Testing Performed:
Tested locally on qemux86

:QA Notes:
None

:Issues Addressed:
None

Signed-off-by: Junil Kim <jjunil79.kim@lge.com>