### PR TITLE
Bug fixing possible null dereferences for launch point

### DIFF
--- a/src/bus/client/DB8.cpp
+++ b/src/bus/client/DB8.cpp
@@ -210,13 +210,16 @@ bool DB8::onFind(LSHandle* sh, LSMessage* message, void* context)
         }
 
         launchPoint = LaunchPointList::getInstance().getByLaunchPointId(launchPointId);
+        if (launchPoint == nullptr) {
+            Logger::warning(getClassName(), __FUNCTION__, "Cannot find launch point");
+            DB8::getInstance().deleteLaunchPoint(launchPointId);
+            continue;
+        }
         if (type == "default") {
             launchPoint->setDatabase(results[i]);
         } else if (type == "bookmark") {
-            if (launchPoint == nullptr) {
-                launchPoint = LaunchPointList::getInstance().createBootmarkByDB(appDesc, results[i]);
-                LaunchPointList::getInstance().add(launchPoint);
-            }
+            launchPoint = LaunchPointList::getInstance().createBootmarkByDB(appDesc, results[i]);
+            LaunchPointList::getInstance().add(launchPoint);
         }
     }
     Logger::info(getInstance().getClassName(), __FUNCTION__, "Complete to sync DB8");

--- a/src/manager/PolicyManager.cpp
+++ b/src/manager/PolicyManager.cpp
@@ -165,6 +165,12 @@ void PolicyManager::onCloseForRemove(LunaTaskPtr lunaTask)
 {
     lunaTask->setSuccessCallback(boost::bind(&PolicyManager::onReplyWithoutIds, this, boost::placeholders::_1));
     LaunchPointPtr launchPoint = LaunchPointList::getInstance().getByLaunchPointId(lunaTask->getLaunchPointId());
+    if (launchPoint == nullptr) {
+        Logger::warning(getClassName(), __FUNCTION__, "Cannot find launch point");
+        lunaTask->setErrCodeAndText(ErrCode_GENERAL, "Cannot find launch point");
+        lunaTask->error(lunaTask);
+        return;
+    }
 
     switch(launchPoint->getType()) {
     case LaunchPointType::LaunchPoint_DEFAULT:


### PR DESCRIPTION
LaunchPointPtr is a pointer initialized by calling getByLaunchPointId.
This function can return a nullptr value, thus LaunchPointPtr could be null.
A check to ensure the validity of the pointer should be always performed before it is used.

A more detailed description is reported in issue https://github.com/webosose/sam/issues/3